### PR TITLE
Don't prevent default when SDL_MOUSEWHEEL event is disabled.

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -376,7 +376,7 @@ Emscripten_HandleWheel(int eventType, const EmscriptenWheelEvent *wheelEvent, vo
 {
     SDL_WindowData *window_data = userData;
     SDL_SendMouseWheel(window_data->window, 0, wheelEvent->deltaX, -wheelEvent->deltaY, SDL_MOUSEWHEEL_NORMAL);
-    return 1;
+    return SDL_GetEventState(SDL_MOUSEWHEEL) == SDL_ENABLE;
 }
 
 int


### PR DESCRIPTION
In our case we explicitly disabled SDL_MOUSEWHEEL to allow user to scroll page even if pointer is over canvas.