### PR TITLE
Prevent stuck keys when user switches away while keys are pressed

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -561,8 +561,8 @@ Emscripten_RegisterEventHandlers(SDL_WindowData *data)
 
     emscripten_set_wheel_callback("#canvas", data, 0, Emscripten_HandleWheel);
 
-    emscripten_set_focus_callback("#canvas", data, 0, Emscripten_HandleFocus);
-    emscripten_set_blur_callback("#canvas", data, 0, Emscripten_HandleFocus);
+    emscripten_set_focus_callback("#window", data, 0, Emscripten_HandleFocus);
+    emscripten_set_blur_callback("#window", data, 0, Emscripten_HandleFocus);
 
     emscripten_set_touchstart_callback("#canvas", data, 0, Emscripten_HandleTouch);
     emscripten_set_touchend_callback("#canvas", data, 0, Emscripten_HandleTouch);
@@ -598,8 +598,8 @@ Emscripten_UnregisterEventHandlers(SDL_WindowData *data)
 
     emscripten_set_wheel_callback("#canvas", NULL, 0, NULL);
 
-    emscripten_set_focus_callback("#canvas", NULL, 0, NULL);
-    emscripten_set_blur_callback("#canvas", NULL, 0, NULL);
+    emscripten_set_focus_callback("#window", NULL, 0, NULL);
+    emscripten_set_blur_callback("#window", NULL, 0, NULL);
 
     emscripten_set_touchstart_callback("#canvas", NULL, 0, NULL);
     emscripten_set_touchend_callback("#canvas", NULL, 0, NULL);

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -383,6 +383,11 @@ int
 Emscripten_HandleFocus(int eventType, const EmscriptenFocusEvent *wheelEvent, void *userData)
 {
     SDL_WindowData *window_data = userData;
+    /* If the user switches away while keys are pressed (such as
+     * via Alt+Tab), key release events won't be received. */
+    if (eventType == EMSCRIPTEN_EVENT_BLUR) {
+        SDL_ResetKeyboard();
+    }
     SDL_SendWindowEvent(window_data->window, eventType == EMSCRIPTEN_EVENT_FOCUS ? SDL_WINDOWEVENT_FOCUS_GAINED : SDL_WINDOWEVENT_FOCUS_LOST, 0, 0);
     return 1;
 }


### PR DESCRIPTION
If the user switches away while keys are pressed, such as with Alt+Tab, key release events aren't received. After Alt+Tab, Alt would remain pressed until the user switches back and presses it again. This should fix that problem. I've tested it in Chrome 40 and Firefox 35. 

Emscripten SDL 1 also un-presses all keys after any visibility change events. That is hopefully unnecessary.
https://github.com/kripken/emscripten/blob/master/src/library_sdl.js#L743

