### PR TITLE
Fix full screen mode in Firefox, which was broken by 9d4beb2

### DIFF
--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -24,6 +24,7 @@
 
 #include "SDL_video.h"
 #include "SDL_mouse.h"
+#include "SDL_hints.h"
 #include "../SDL_sysvideo.h"
 #include "../SDL_pixels_c.h"
 #include "../SDL_egl_c.h"
@@ -74,6 +75,9 @@ Emscripten_CreateDevice(int devindex)
         SDL_OutOfMemory();
         return (0);
     }
+
+    /* Firefox sends blur event which would otherwise prevent full screen */
+    SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 
     /* Set the function pointers */
     device->VideoInit = Emscripten_VideoInit;


### PR DESCRIPTION
This is the same branch that was used in #7, with one additional commit beyond the merge point of 7, fixing the full screen issue using `SDL_SetHint()`. I don't know if I really need to create another pull request in this situation, but here it is, for convenience.