### PR TITLE
Check if device pixel ratio has changed

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -531,6 +531,10 @@ EM_BOOL
 Emscripten_HandleResize(int eventType, const EmscriptenUiEvent *uiEvent, void *userData)
 {
     SDL_WindowData *window_data = userData;
+
+    /* update pixel ratio */
+    window_data->pixel_ratio = emscripten_get_device_pixel_ratio();
+
     if(!(window_data->window->flags & FULLSCREEN_MASK))
     {
         /* this will only work if the canvas size is set through css */

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -209,7 +209,7 @@ Emscripten_CreateWindow(_THIS, SDL_Window * window)
 
     emscripten_get_element_css_size(NULL, &css_w, &css_h);
 
-    wdata->external_size = css_w != scaled_w || css_h != scaled_h;
+    wdata->external_size = SDL_floor(css_w) != scaled_w || SDL_floor(css_h) != scaled_h;
 
     if ((window->flags & SDL_WINDOW_RESIZABLE) && wdata->external_size) {
         /* external css has resized us */
@@ -262,6 +262,8 @@ static void Emscripten_SetWindowSize(_THIS, SDL_Window * window)
 
     if (window->driverdata) {
         data = (SDL_WindowData *) window->driverdata;
+        /* update pixel ratio */
+        data->pixel_ratio = emscripten_get_device_pixel_ratio();
         emscripten_set_canvas_size(window->w * data->pixel_ratio, window->h * data->pixel_ratio);
 
         /*scale canvas down*/


### PR DESCRIPTION
This pr addresses the issue that the device pixel ratio can change when there is a browser zoom action and the window_data structure was not following this change.
Also on when creating the window there is a comparison of the css size (a double) with the scaled window size (int), which did not make any sense when the css is not integral.