### PR TITLE
Fixed onaudioprocess finalizing

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -225,6 +225,7 @@ EMSCRIPTENAUDIO_CloseDevice(_THIS)
             SDL2.capture = undefined;
         } else {
             if (SDL2.audio.scriptProcessorNode != undefined) {
+                SDL2.audio.scriptProcessorNode.onaudioprocess = function(audioProcessingEvent) {};
                 SDL2.audio.scriptProcessorNode.disconnect();
                 SDL2.audio.scriptProcessorNode = undefined;
             }


### PR DESCRIPTION
There is an edge case, when audio callback is still called after closing audio device, which leads to crash because audio device doesn't exists anymore. In this function there is a proper scriptProcessorNode finalizing code, but only for "if capture is enabled" branch, which is placed above.

So the fix is to use the same method for clearing onaudioprocess as in the code above.