### PR TITLE
actually use cursor hotspot

### DIFF
--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -116,7 +116,9 @@ Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
         }
 
         ctx.putImageData(image, 0, 0);
-        var url = "url(" + canvas.toDataURL() + ") " + hot_x + " " + hot_y + ", auto";
+        var url = hot_x === 0 && hot_y === 0
+            ? "url(" + canvas.toDataURL() + "), auto"
+            : "url(" + canvas.toDataURL() + ") " + hot_x + " " + hot_y + ", auto";
 
         var urlBuf = _malloc(url.length + 1);
         stringToUTF8(url, urlBuf, url.length + 1);

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -79,7 +79,9 @@ Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
     cursor_url = (const char *)EM_ASM_INT({
         var w = $0;
         var h = $1;
-        var pixels = $2;
+        var hot_x = $2;
+        var hot_y = $3;
+        var pixels = $4;
 
         var canvas = document.createElement("canvas");
         canvas.width = w;
@@ -114,13 +116,13 @@ Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
         }
 
         ctx.putImageData(image, 0, 0);
-        var url = "url(" + canvas.toDataURL() + "), auto";
+        var url = "url(" + canvas.toDataURL() + ") " + hot_x + " " + hot_y + ", auto";
 
         var urlBuf = _malloc(url.length + 1);
         stringToUTF8(url, urlBuf, url.length + 1);
 
         return urlBuf;
-    }, surface->w, surface->h, conv_surf->pixels);
+    }, surface->w, surface->h, hot_x, hot_y, conv_surf->pixels);
 
     SDL_FreeSurface(conv_surf);
 


### PR DESCRIPTION
The cursor's hotspot simply wasn't translated to its CSS equivalent, yet. So SDL games that use custom cursors would have their emscriptened counterpart display those cursors such that *always* the top left corner of the sprite is the hotspot, regardless of what was specified (`Emscripten_CreateCursor`'s `hot_x` and `hot_y` parameters).

See https://developer.mozilla.org/en-US/docs/Web/CSS/cursor?v=example#Syntax