### PR TITLE
Implement multi-window support

### DIFF
--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -61,6 +61,11 @@ int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rec
     SDL_Surface *surface;
 
     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+
+    if (!data->selected) {
+        return 0;
+    }
+
     surface = data->surface;
     if (!surface) {
         return SDL_SetError("Couldn't find framebuffer surface for window");

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -47,6 +47,9 @@ typedef struct SDL_WindowData
 
     SDL_bool finger_touching;  /* for mapping touch events to mice */
     SDL_FingerID first_finger;
+
+    /* we have single canvas that reflects only one window at a time */
+    SDL_bool selected;
 } SDL_WindowData;
 
 #endif /* _SDL_emscriptenvideo_h */


### PR DESCRIPTION
In my port of QEMU to JavaScript I use their SDL2 UI for graphics. Previously, I had to disable every window except one, otherwise the canvas was messed up.

In this PR, SDL2 support for multiple windows is implemented for Emscripten.

This PR relies on window selector from Emscripten runtime (kripken/emscripten#6374) but should work in single-window case when window selector is not supported.

PS: Frankly speaking, I'm not familiar with OpenGL at all, but it seems to work in my QEMU port. Corrections are welcome, of course. You can test it with this [kludgy gist](https://gist.github.com/atrosinenko/4f433ee15a3aeef64b5e829602cd3366).

