### PR TITLE
Fixed SDL_SYSTEM_CURSOR_SIZEALL

### DIFF
--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -165,6 +165,7 @@ Emscripten_CreateSystemCursor(SDL_SystemCursor id)
             cursor_name = "ns-resize";
             break;
         case SDL_SYSTEM_CURSOR_SIZEALL:
+            cursor_name = "move";
             break;
         case SDL_SYSTEM_CURSOR_NO:
             cursor_name = "not-allowed";


### PR DESCRIPTION
Just a quick fix to get the move cursor working.

Closes #54 