### PR TITLE
Make CloseAudio actually close audio

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -246,6 +246,7 @@ EMSCRIPTENAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscaptu
     }
     SDL_zerop(this->hidden);
 #endif
+    this->hidden = (struct SDL_PrivateAudioData *)0x1;
 
     /* limit to native freq */
     this->spec.freq = EM_ASM_INT_V({ return SDL2.audioContext.sampleRate; });


### PR DESCRIPTION
Currently CloseAudio is a no-op. Consequently the audio callback keeps being called even after exiting the program, causing an endless stream of errors in the console.

This one-line patch fixes the issue.

Note: this was reported at https://bugzilla.libsdl.org/show_bug.cgi?id=4176
but upstream does not seem reactive. Any way to push it for inclusion there?