### PR TITLE
Emscripten: fix duplicate mousebuttonup/mousebuttondown events when touch events are disabled

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -458,6 +458,7 @@ Emscripten_HandleTouch(int eventType, const EmscriptenTouchEvent *touchEvent, vo
             }
             SDL_SendTouch(deviceId, id, SDL_TRUE, x, y, 1.0f);
 
+            /* disable browser scrolling/pinch-to-zoom if app handles touch events */
             if (!preventDefault && SDL_GetEventState(SDL_FINGERDOWN) == SDL_ENABLE) {
                 preventDefault = 1;
             }
@@ -466,10 +467,6 @@ Emscripten_HandleTouch(int eventType, const EmscriptenTouchEvent *touchEvent, vo
                 SDL_SendMouseMotion(window_data->window, SDL_TOUCH_MOUSEID, 0, mx, my);
             }
             SDL_SendTouchMotion(deviceId, id, x, y, 1.0f);
-
-            if (!preventDefault && SDL_GetEventState(SDL_FINGERMOTION) == SDL_ENABLE) {
-                preventDefault = 1;
-            }
         } else {
             if ((window_data->finger_touching) && (window_data->first_finger == id)) {
                 SDL_SendMouseButton(window_data->window, SDL_TOUCH_MOUSEID, SDL_RELEASED, SDL_BUTTON_LEFT);
@@ -477,9 +474,8 @@ Emscripten_HandleTouch(int eventType, const EmscriptenTouchEvent *touchEvent, vo
             }
             SDL_SendTouch(deviceId, id, SDL_FALSE, x, y, 1.0f);
 
-            if (!preventDefault && SDL_GetEventState(SDL_FINGERUP) == SDL_ENABLE) {
-                preventDefault = 1;
-            }
+            /* block browser's simulated mousedown/mouseup on touchscreen devices */
+            preventDefault = 1;
         }
     }
 


### PR DESCRIPTION
Both SDL2 and the browser attempt to simulate mouse events from touch events.
As a result we may get duplicates.

By default, on touch event on the canvas we generates fake mouse events with mouse identifier `which=SDL_TOUCH_MOUSEID`.

However if we disable touch events:
```
  SDL_EventState(SDL_FINGERDOWN, 0);
  SDL_EventState(SDL_FINGERUP, 0);
```
then we still generate the fake mouse events (from browser's touchstart/touchend, because the touch handler is still called even if the events are not passed to the application), but we also generate duplicate events from mouse identifier `which=0` (from browser's simulated mousedown/mouseup - which were not triggered before as the touch handler currently issues a preventDefault when touch events are enabled).

This is not consistent with e.g. the Android SDL port, in which we simply always get the mouse events from `which=SDL_TOUCH_MOUSEID` (plus the touch events, if enabled).
(There's also an Android SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH mode but that's separate and used to stop generating fake mouse events entirely.)

According to https://wiki.libsdl.org/SDL_MouseButtonEvent#Remarks, the right events we need to propagate are the SDL_TOUCH_MOUSEID ones.

With this patch the behavior is consistent with the Android port with both enabled and disabled touch events.

What do you think?