### PR TITLE
Emscripten: fix fullscreen toggle when user presses Escape

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -562,6 +562,12 @@ Emscripten_HandleFullscreenChange(int eventType, const EmscriptenFullscreenChang
     }
     else
     {
+        if ((window_data->requested_fullscreen_mode & FULLSCREEN_MASK)
+	    != (window_data->window->flags & FULLSCREEN_MASK)) {
+	  // User pressed Escape
+	  // State inconsistent as SDL_SetWindowFullscreen was not called, let's fix:
+	  SDL_SetWindowFullscreen(window_data->window, 0);
+	}
         window_data->window->flags &= ~FULLSCREEN_MASK;
     }
 


### PR DESCRIPTION
Hi!

When fullscreen is toggled e.g. by pressing 'F' in the application, and if the user goes back to windowed mode *not* by pressing 'F' again, but by obeying the browser and pressing 'Escape', then SDL gets in an inconsistent state.
The user will then need to press 'F' (or otherwise request fullscreen toggle) 3 times to get actual fullscreen back, the first 2 times will be ignored.

This patch fixes SDL's state when the user presses "Escape".