### PR TITLE
When acceleration is set, set EGL image priority to high

### DIFF
--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -1,15 +1,15 @@
 /*
  *  Simple DirectMedia Layer
  *  Copyright (C) 1997-2017 Sam Lantinga <slouken@libsdl.org>
- * 
+ *
  *  This software is provided 'as-is', without any express or implied
  *  warranty.  In no event will the authors be held liable for any damages
  *  arising from the use of this software.
- * 
+ *
  *  Permission is granted to anyone to use this software for any purpose,
  *  including commercial applications, and to alter it and redistribute it
  *  freely, subject to the following restrictions:
- * 
+ *
  *  1. The origin of this software must not be misrepresented; you must not
  *     claim that you wrote the original software. If you use this software
  *     in a product, an acknowledgment in the product documentation would be
@@ -204,7 +204,7 @@ SDL_EGL_GetProcAddress(_THIS, const char *proc)
 {
     static char procname[1024];
     void *retval;
-    
+
     /* eglGetProcAddress is busted on Android http://code.google.com/p/android/issues/detail?id=7681 */
 #if !defined(SDL_VIDEO_DRIVER_ANDROID)
     if (_this->egl_data->eglGetProcAddress) {
@@ -214,7 +214,7 @@ SDL_EGL_GetProcAddress(_THIS, const char *proc)
         }
     }
 #endif
-    
+
     retval = SDL_LoadFunction(_this->egl_data->egl_dll_handle, proc);
     if (!retval && SDL_strlen(proc) <= 1022) {
         procname[0] = '_';
@@ -241,7 +241,7 @@ SDL_EGL_UnloadLibrary(_THIS)
             SDL_UnloadObject(_this->egl_data->egl_dll_handle);
             _this->egl_data->egl_dll_handle = NULL;
         }
-        
+
         SDL_free(_this->egl_data);
         _this->egl_data = NULL;
     }
@@ -310,12 +310,12 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
                 }
             }
         }
-#ifdef DEFAULT_OGL         
+#ifdef DEFAULT_OGL
         else {
             path = DEFAULT_OGL;
             egl_dll_handle = SDL_LoadObject(path);
         }
-#endif        
+#endif
     }
     _this->egl_data->egl_dll_handle = egl_dll_handle;
 
@@ -326,7 +326,7 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
     /* Loading libGL* in the previous step took care of loading libEGL.so, but we future proof by double checking */
     if (egl_path != NULL) {
         dll_handle = SDL_LoadObject(egl_path);
-    }   
+    }
     /* Try loading a EGL symbol, if it does not work try the default library paths */
     if (dll_handle == NULL || SDL_LoadFunction(dll_handle, "eglChooseConfig") == NULL) {
         if (dll_handle != NULL) {
@@ -414,7 +414,7 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
     if (_this->egl_data->egl_display == EGL_NO_DISPLAY) {
         return SDL_SetError("Could not get EGL display");
     }
-    
+
     if (_this->egl_data->eglInitialize(_this->egl_data->egl_display, NULL, NULL) != EGL_TRUE) {
         return SDL_SetError("Could not initialize EGL");
     }
@@ -425,12 +425,12 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
     } else {
         *_this->gl_config.driver_path = '\0';
     }
-    
+
     return 0;
 }
 
 int
-SDL_EGL_ChooseConfig(_THIS) 
+SDL_EGL_ChooseConfig(_THIS)
 {
 /* 64 seems nice. */
     EGLint attribs[64];
@@ -444,12 +444,12 @@ SDL_EGL_ChooseConfig(_THIS)
     EGLConfig configs[128];
 #endif
     int i, j, best_bitdiff = -1, bitdiff;
-   
+
     if (!_this->egl_data) {
         /* The EGL library wasn't loaded, SDL_GetError() should have info */
         return -1;
     }
-  
+
     /* Get a valid EGL configuration */
     i = 0;
     attribs[i++] = EGL_RED_SIZE;
@@ -458,30 +458,35 @@ SDL_EGL_ChooseConfig(_THIS)
     attribs[i++] = _this->gl_config.green_size;
     attribs[i++] = EGL_BLUE_SIZE;
     attribs[i++] = _this->gl_config.blue_size;
-    
+
     if (_this->gl_config.alpha_size) {
         attribs[i++] = EGL_ALPHA_SIZE;
         attribs[i++] = _this->gl_config.alpha_size;
     }
-    
+
     if (_this->gl_config.buffer_size) {
         attribs[i++] = EGL_BUFFER_SIZE;
         attribs[i++] = _this->gl_config.buffer_size;
     }
-    
+
     attribs[i++] = EGL_DEPTH_SIZE;
     attribs[i++] = _this->gl_config.depth_size;
-    
+
+    if (_this->gl_config.accelerated) {
+        attribs[i++] = EGL_CONTEXT_PRIORITY_LEVEL_IMG;
+        attribs[i++] = EGL_CONTEXT_PRIORITY_HIGH_IMG;
+    }
+
     if (_this->gl_config.stencil_size) {
         attribs[i++] = EGL_STENCIL_SIZE;
         attribs[i++] = _this->gl_config.stencil_size;
     }
-    
+
     if (_this->gl_config.multisamplebuffers) {
         attribs[i++] = EGL_SAMPLE_BUFFERS;
         attribs[i++] = _this->gl_config.multisamplebuffers;
     }
-    
+
     if (_this->gl_config.multisamplesamples) {
         attribs[i++] = EGL_SAMPLES;
         attribs[i++] = _this->gl_config.multisamplesamples;
@@ -537,7 +542,7 @@ SDL_EGL_ChooseConfig(_THIS)
             if (attribs[j] == EGL_NONE) {
                break;
             }
-            
+
             if ( attribs[j+1] != EGL_DONT_CARE && (
                 attribs[j] == EGL_RED_SIZE ||
                 attribs[j] == EGL_GREEN_SIZE ||
@@ -552,7 +557,7 @@ SDL_EGL_ChooseConfig(_THIS)
 
         if (bitdiff < best_bitdiff || best_bitdiff == -1) {
             _this->egl_data->egl_config = configs[i];
-            
+
             best_bitdiff = bitdiff;
         }
 
@@ -560,7 +565,7 @@ SDL_EGL_ChooseConfig(_THIS)
             break; /* we found an exact match! */
         }
     }
-    
+
     return 0;
 }
 
@@ -688,8 +693,8 @@ SDL_EGL_MakeCurrent(_THIS, EGLSurface egl_surface, SDL_GLContext context)
     if (!_this->egl_data) {
         return SDL_SetError("OpenGL not initialized");
     }
-    
-    /* The android emulator crashes badly if you try to eglMakeCurrent 
+
+    /* The android emulator crashes badly if you try to eglMakeCurrent
      * with a valid context and invalid surface, so we have to check for both here.
      */
     if (!egl_context || !egl_surface) {
@@ -700,7 +705,7 @@ SDL_EGL_MakeCurrent(_THIS, EGLSurface egl_surface, SDL_GLContext context)
             return SDL_EGL_SetError("Unable to make EGL context current", "eglMakeCurrent");
         }
     }
-      
+
     return 0;
 }
 
@@ -708,17 +713,17 @@ int
 SDL_EGL_SetSwapInterval(_THIS, int interval)
 {
     EGLBoolean status;
-    
+
     if (!_this->egl_data) {
         return SDL_SetError("EGL not initialized");
     }
-    
+
     status = _this->egl_data->eglSwapInterval(_this->egl_data->egl_display, interval);
     if (status == EGL_TRUE) {
         _this->egl_data->egl_swapinterval = interval;
         return 0;
     }
-    
+
     return SDL_EGL_SetError("Unable to set the EGL swap interval", "eglSwapInterval");
 }
 
@@ -729,7 +734,7 @@ SDL_EGL_GetSwapInterval(_THIS)
         SDL_SetError("EGL not initialized");
         return 0;
     }
-    
+
     return _this->egl_data->egl_swapinterval;
 }
 
@@ -751,37 +756,37 @@ SDL_EGL_DeleteContext(_THIS, SDL_GLContext context)
     if (!_this->egl_data) {
         return;
     }
-    
+
     if (egl_context != NULL && egl_context != EGL_NO_CONTEXT) {
         SDL_EGL_MakeCurrent(_this, NULL, NULL);
         _this->egl_data->eglDestroyContext(_this->egl_data->egl_display, egl_context);
     }
-        
+
 }
 
 EGLSurface *
-SDL_EGL_CreateSurface(_THIS, NativeWindowType nw) 
+SDL_EGL_CreateSurface(_THIS, NativeWindowType nw)
 {
     EGLSurface * surface;
 
     if (SDL_EGL_ChooseConfig(_this) != 0) {
         return EGL_NO_SURFACE;
     }
-    
+
 #if SDL_VIDEO_DRIVER_ANDROID
     {
         /* Android docs recommend doing this!
-         * Ref: http://developer.android.com/reference/android/app/NativeActivity.html 
+         * Ref: http://developer.android.com/reference/android/app/NativeActivity.html
          */
         EGLint format;
         _this->egl_data->eglGetConfigAttrib(_this->egl_data->egl_display,
-                                            _this->egl_data->egl_config, 
+                                            _this->egl_data->egl_config,
                                             EGL_NATIVE_VISUAL_ID, &format);
 
         ANativeWindow_setBuffersGeometry(nw, 0, 0, format);
     }
-#endif    
-    
+#endif
+
     surface = _this->egl_data->eglCreateWindowSurface(
             _this->egl_data->egl_display,
             _this->egl_data->egl_config,
@@ -793,12 +798,12 @@ SDL_EGL_CreateSurface(_THIS, NativeWindowType nw)
 }
 
 void
-SDL_EGL_DestroySurface(_THIS, EGLSurface egl_surface) 
+SDL_EGL_DestroySurface(_THIS, EGLSurface egl_surface)
 {
     if (!_this->egl_data) {
         return;
     }
-    
+
     if (egl_surface != EGL_NO_SURFACE) {
         _this->egl_data->eglDestroySurface(_this->egl_data->egl_display, egl_surface);
     }


### PR DESCRIPTION
This is plumbing to enable SDL2 apps compiled with Emscripten to set low latency hint on the target canvas. We can read the image priority property in the Emscripten EGL library and update the gl context attributes there.