### PR TITLE
Fixed opening brace issue when SDL_PROTOTYPES_ONLY is defined

### DIFF
--- a/include/SDL_syswm.h
+++ b/include/SDL_syswm.h
@@ -43,6 +43,13 @@
  */
 #ifdef SDL_PROTOTYPES_ONLY
 struct SDL_SysWMinfo;
+
+#include "begin_code.h"
+/* Set up for C function definitions, even when using C++ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
 #else
 
 #if defined(SDL_VIDEO_DRIVER_WINDOWS)


### PR DESCRIPTION
Hello,
When SDL_PROTOTYPES_ONLY is being defined, there is a compilation error because of a missing opening brace in SDL_SysWM.h

The missing code is
```
#ifdef __cplusplus
extern "C" {
#endif
```
... in the #ifdef SDL_PROTOTYPES_ONLY block

(this code is already done in the #else block. The corresponding closing brace is always done at the end of the file, regardless of the definition of SDL_PROTOTYPES_ONLY)

This PR solves the issue
