### PR TITLE
Let SDL_GetDisplayUsableBounds return the size of the window

### DIFF
--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -42,6 +42,7 @@
 static int Emscripten_VideoInit(_THIS);
 static int Emscripten_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode);
 static void Emscripten_VideoQuit(_THIS);
+static int Emscripten_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
 
 static int Emscripten_CreateWindow(_THIS, SDL_Window * window);
 static void Emscripten_SetWindowSize(_THIS, SDL_Window * window);
@@ -86,6 +87,7 @@ Emscripten_CreateDevice(int devindex)
     /* Set the function pointers */
     device->VideoInit = Emscripten_VideoInit;
     device->VideoQuit = Emscripten_VideoQuit;
+    device->GetDisplayUsableBounds = Emscripten_GetDisplayUsableBounds;
     device->SetDisplayMode = Emscripten_SetDisplayMode;
 
 
@@ -175,6 +177,22 @@ static void
 Emscripten_VideoQuit(_THIS)
 {
     Emscripten_FiniMouse();
+}
+
+static int
+Emscripten_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
+{
+    if (rect) {
+        rect->x = 0;
+        rect->y = 0;
+        rect->w = EM_ASM_INT_V({
+            return window.innerWidth;
+        });
+        rect->h = EM_ASM_INT_V({
+            return window.innerHeight;
+        });
+    }
+    return 0;
 }
 
 static void


### PR DESCRIPTION
See: https://github.com/emscripten-ports/SDL2/issues/100

Note that this does not account for possible margins and scrollbars. However, if your emscripten page is opened in an iframe (like on itch.io) then using the UsableBounds gives a much more accurate size then the DisplaySize.