### PR TITLE
emscripten: Pass canvas id to request_pointer_lock

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -363,7 +363,7 @@ Emscripten_HandleMouseButton(int eventType, const EmscriptenMouseEvent *mouseEve
 
     if (eventType == EMSCRIPTEN_EVENT_MOUSEDOWN) {
         if (SDL_GetMouse()->relative_mode && !window_data->has_pointer_lock) {
-            emscripten_request_pointerlock(NULL, 0);  /* try to regrab lost pointer lock. */
+            emscripten_request_pointerlock(window_data->canvas_id, 0);  /* try to regrab lost pointer lock. */
         }
         sdl_button_state = SDL_PRESSED;
         sdl_event_type = SDL_MOUSEBUTTONDOWN;

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -28,6 +28,7 @@
 #include <emscripten/html5.h>
 
 #include "SDL_emscriptenmouse.h"
+#include "SDL_emscriptenvideo.h"
 
 #include "../../events/SDL_mouse_c.h"
 #include "SDL_assert.h"
@@ -236,9 +237,19 @@ Emscripten_WarpMouse(SDL_Window* window, int x, int y)
 static int
 Emscripten_SetRelativeMouseMode(SDL_bool enabled)
 {
+    SDL_Window *window;
+    SDL_WindowData *window_data;
+
     /* TODO: pointer lock isn't actually enabled yet */
     if(enabled) {
-        if(emscripten_request_pointerlock(NULL, 1) >= EMSCRIPTEN_RESULT_SUCCESS) {
+        window = SDL_GetMouseFocus();
+        if (window == NULL) {
+            return -1;
+        }
+
+        window_data = (SDL_WindowData *) window->driverdata;
+
+        if(emscripten_request_pointerlock(window_data->canvas_id, 1) >= EMSCRIPTEN_RESULT_SUCCESS) {
             return 0;
         }
     } else {


### PR DESCRIPTION
Fixes pointer lock with DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1

fixes #99 