### PR TITLE
emscripten: Remove Module[] from setWindowTitle

### DIFF
--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -366,8 +366,8 @@ Emscripten_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * di
 static void
 Emscripten_SetWindowTitle(_THIS, SDL_Window * window) {
     EM_ASM_INT({
-      if (typeof Module['setWindowTitle'] !== 'undefined') {
-        Module['setWindowTitle'](UTF8ToString($0));
+      if (typeof setWindowTitle !== 'undefined') {
+        setWindowTitle(UTF8ToString($0));
       }
       return 0;
     }, window->title);


### PR DESCRIPTION
Noticed that there was a TODO for this: https://github.com/emscripten-core/emscripten/blob/7c3ced64d51be643f7a12bb34e8b875155d49dc7/src/shell.js#L386
 