### PR TITLE
Extend the "nav key" blacklist

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -583,7 +583,10 @@ Emscripten_HandleKey(int eventType, const EmscriptenKeyboardEvent *keyEvent, voi
                  keyEvent->keyCode == 37 /* left */ ||
                  keyEvent->keyCode == 38 /* up */ ||
                  keyEvent->keyCode == 39 /* right */ ||
-                 keyEvent->keyCode == 40 /* down */;
+                 keyEvent->keyCode == 40 /* down */ ||
+                 (keyEvent->keyCode >= 112 && keyEvent->keyCode <= 135) /* F keys*/ ||
+                 keyEvent->ctrlKey ||
+                 keyEvent->altKey;
 
     if (eventType == EMSCRIPTEN_EVENT_KEYDOWN && SDL_GetEventState(SDL_TEXTINPUT) == SDL_ENABLE && !is_nav_key)
         prevent_default = SDL_FALSE;


### PR DESCRIPTION
Mentioned in #118, I think this is consistent with the disabling of other keys. Shouldn't break anything as we wouldn't get keypress events for those anyway. Also related to #60?