### PR TITLE
Fix mutex ownership in pthread SDL_CondWait()

### DIFF
--- a/src/thread/pthread/SDL_syscond.c
+++ b/src/thread/pthread/SDL_syscond.c
@@ -134,6 +134,10 @@ SDL_CondWaitTimeout(SDL_cond * cond, SDL_mutex * mutex, Uint32 ms)
         retval = SDL_MUTEX_TIMEDOUT;
         break;
     case 0:
+#if FAKE_RECURSIVE_MUTEX
+        mutex->owner = pthread_self();
+        mutex->recursive = 0;
+#endif
         break;
     default:
         retval = SDL_SetError("pthread_cond_timedwait() failed");
@@ -152,6 +156,10 @@ SDL_CondWait(SDL_cond * cond, SDL_mutex * mutex)
     } else if (pthread_cond_wait(&cond->cond, &mutex->id) != 0) {
         return SDL_SetError("pthread_cond_wait() failed");
     }
+#if FAKE_RECURSIVE_MUTEX 
+    mutex->owner = pthread_self();
+    mutex->recursive = 0;
+#endif
     return 0;
 }
 

--- a/src/thread/pthread/SDL_sysmutex_c.h
+++ b/src/thread/pthread/SDL_sysmutex_c.h
@@ -23,9 +23,18 @@
 #ifndef SDL_mutex_c_h_
 #define SDL_mutex_c_h_
 
+#if !SDL_THREAD_PTHREAD_RECURSIVE_MUTEX && \
+    !SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP
+#define FAKE_RECURSIVE_MUTEX 1
+#endif
+
 struct SDL_mutex
 {
     pthread_mutex_t id;
+#if FAKE_RECURSIVE_MUTEX
+    int recursive;
+    pthread_t owner;
+#endif
 };
 
 #endif /* SDL_mutex_c_h_ */


### PR DESCRIPTION
This commit fixes a following bug in pthread versions of `SDL_CondWait()` and `SDL_CondWaitTimeout()`:

When call to `pthread_cond_wait()` (or `pthread_cond_timedwait()`) succeeds and the current thread reacquires the `pthread_mutex`, it doesn't properly update its wrapper (the `SDL_mutex` object). If `FAKE_RECURSIVE_MUTEX` is set, this leads to problems in the following scenario:

```
SDL_mutex *mutex;
SDL_cond *cond;

Thread A:    
  SDL_LockMutex(mutex);
  SDL_CondWait(cond, mutex);
  SDL_UnlockMutex(mutex);
Thread B:
  SDL_LockMutex(mutex);
  SDL_UnlockMutex(mutex);
  SDL_CondSignal(cond);

Execution:
  Thread A: SDL_LockMutex(mutex);
  Thread A: SDL_CondWait(cond, mutex); // releases mutex and blocks
  Thread B: SDL_LockMutex(mutex);      // updates mutex->owner to Thread B
  Thread B: SDL_UnlockMutex(mutex);    // updates mutex->owner to 0
  Thread B: SDL_CondSignal(conde);     // unblocks Thread A
  Thread A: SDL_UnlockMutex(mutex);    // error: mutex not owned by this thread
```