### PR TITLE
Don't flag window as fullscreen on external requests

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -597,9 +597,6 @@ Emscripten_HandleFullscreenChange(int eventType, const EmscriptenFullscreenChang
         window_data->window->flags |= window_data->requested_fullscreen_mode;
 
         window_data->requested_fullscreen_mode = 0;
-
-        if(!window_data->requested_fullscreen_mode)
-            window_data->window->flags |= SDL_WINDOW_FULLSCREEN; /*we didn't request fullscreen*/
     }
     else
     {


### PR DESCRIPTION
This patch changes SDL not to flag window as fullscreen when the fullscreen request did not come from SDL, but e.g. directly via [element.requestFullscreen](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen).

This enables use of `SDL_SetWindowSize` together with `emscripten_get_element_css_size` to create a fully responsive canvas - one where the canvas resolution always matches CSS dimensions (including fullscreen) - while also keeping SDL internals synchronized (such as mouse coordinate translation).

Without this patch, it is impossible to use SDL_SetWindowSize in this manner after using `element.requestFullscreen`, because `SDL_SetWindowSize` changes behavior.

Closes: #138 