### PR TITLE
Decrease vertical scroll speed by using deltaMode

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -409,7 +409,22 @@ static EM_BOOL
 Emscripten_HandleWheel(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData)
 {
     SDL_WindowData *window_data = userData;
-    SDL_SendMouseWheel(window_data->window, 0, (float)wheelEvent->deltaX, (float)-wheelEvent->deltaY, SDL_MOUSEWHEEL_NORMAL);
+
+    float deltaY = wheelEvent->deltaY;
+
+    switch (wheelEvent->deltaMode) {
+        case DOM_DELTA_PIXEL:
+            deltaY /= 100; /* 100 pixels make up a step */
+            break;
+        case DOM_DELTA_LINE:
+            deltaY /= 3; /* 3 lines make up a step */
+            break;
+        case DOM_DELTA_PAGE:
+            deltaY *= 80; /* A page makes up 80 steps */
+            break;
+    }
+
+    SDL_SendMouseWheel(window_data->window, 0, (float)wheelEvent->deltaX, -deltaY, SDL_MOUSEWHEEL_NORMAL);
     return SDL_GetEventState(SDL_MOUSEWHEEL) == SDL_ENABLE;
 }
 


### PR DESCRIPTION
Resolves https://github.com/emscripten-ports/SDL2/issues/149

This works for me (it makes scrolling interfaces that were very hard to use before usable!) but I don't know how to test. This would be a major behavior change for anything using scrolling in SDL2, but should be more consistent with native SDL2.